### PR TITLE
Add buttons for creating connections and servers in the sidebar

### DIFF
--- a/apps/app/src/features/sidebar/app-sidebar.tsx
+++ b/apps/app/src/features/sidebar/app-sidebar.tsx
@@ -1,12 +1,8 @@
-import { Button } from "@local-sql/ui/components/button";
-import { Icons } from "@local-sql/ui/components/icons";
 import {
   Sidebar,
   SidebarFooter,
-  SidebarHeader,
   SidebarRail,
 } from "@local-sql/ui/components/sidebar";
-import { CreateServerDialog } from "../server/create-server.dialog";
 import { secondaryNavData } from "./data/nav.secondary.data";
 import { NavMain } from "./nav.main";
 import { NavSecondary } from "./nav.secondary";
@@ -14,14 +10,6 @@ import { NavSecondary } from "./nav.secondary";
 export const AppSidebar = () => {
   return (
     <Sidebar className="font-medium">
-      <SidebarHeader>
-        <CreateServerDialog>
-          <Button variant={"outline"} size={"sm"}>
-            Add server
-            <Icons.Plus />
-          </Button>
-        </CreateServerDialog>
-      </SidebarHeader>
       <NavMain />
       <SidebarFooter>
         <NavSecondary items={secondaryNavData} />

--- a/apps/app/src/features/sidebar/main/server-sidebar-group.tsx
+++ b/apps/app/src/features/sidebar/main/server-sidebar-group.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LOCAL_SERVER_ID } from "@local-sql/db-types";
+import { Button } from "@local-sql/ui/components/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -94,6 +95,23 @@ export const ServerSidebarGroup = ({ server }: ServerSidebarGroupProps) => {
           </SidebarGroupAction>
         </DropdownMenuTrigger>
       </ServerSidebarDropdownMenu>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {server.connections.length === 0 && (
+            <Button
+              size={"sm"}
+              variant={"ghost"}
+              onClick={() => setIsNewConnOpen(true)}
+            >
+              Add first connection <Icons.Plus />
+            </Button>
+          )}
+          {server.connections.map((conn) => (
+            <DatabaseMenuItem key={conn.id} server={server} connection={conn} />
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+
       <CreateConnectionDialog
         serverId={server.id}
         isOpen={isNewConnOpen}
@@ -115,13 +133,6 @@ export const ServerSidebarGroup = ({ server }: ServerSidebarGroupProps) => {
         isOpen={isTokensOpen}
         setIsOpen={setIsTokensOpen}
       />
-      <SidebarGroupContent>
-        <SidebarMenu>
-          {server.connections.map((conn) => (
-            <DatabaseMenuItem key={conn.id} server={server} connection={conn} />
-          ))}
-        </SidebarMenu>
-      </SidebarGroupContent>
     </SidebarGroup>
   );
 };

--- a/apps/app/src/features/sidebar/nav.main.tsx
+++ b/apps/app/src/features/sidebar/nav.main.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { SidebarContent } from "@local-sql/ui/components/sidebar";
+import { Button } from "@local-sql/ui/components/button";
+import { Icons } from "@local-sql/ui/components/icons";
+import { SidebarContent, SidebarGroup } from "@local-sql/ui/components/sidebar";
 import { useServersStore } from "@/store/servers.store";
+import { CreateServerDialog } from "../server/create-server.dialog";
 import { ServerSidebarGroup } from "./main/server-sidebar-group";
 
 export const NavMain = () => {
@@ -12,6 +15,14 @@ export const NavMain = () => {
       {servers.map((server) => (
         <ServerSidebarGroup key={server.id} server={server} />
       ))}
+      <SidebarGroup>
+        <CreateServerDialog>
+          <Button variant={"outline"} size={"sm"}>
+            Add server
+            <Icons.Plus />
+          </Button>
+        </CreateServerDialog>
+      </SidebarGroup>
     </SidebarContent>
   );
 };


### PR DESCRIPTION
Introduce a button to create the first connection in the server sidebar and relocate the add server button to the main navigation content.